### PR TITLE
Readme: fix header rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#HxJsonDef
+# HxJsonDef
 
 ![](icon.png)
 


### PR DESCRIPTION
GitHub seems to have recently made a change to their markdown renderer, making the space after `#` mandatory.